### PR TITLE
Fix for newer installers

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -254,8 +254,8 @@ namespace UnityNSISReader
                 lzmadecoder.SetDecoderProperties(properties);
                 //long fileLength = BitConverter.ToInt64(buffer, 5);
                 //Console.WriteLine("[LZMA] fileLength: " + fileLength);
-                MemoryStream outputStream = new MemoryStream(1 << 20);
-                lzmadecoder.Code(fs, outputStream, arcSize - 5, 1 << 20, null);
+                MemoryStream outputStream = new MemoryStream(1 << 24);
+                lzmadecoder.Code(fs, outputStream, arcSize - 5, 1 << 24, null);
                 if (isSolid)
                 {
                     byte[] buf = new byte[4];
@@ -463,6 +463,10 @@ namespace UnityNSISReader
                                 if (!string.IsNullOrEmpty(filter) && !Regex.IsMatch(filePathLocal, filter))
                                     continue;
 
+                                if (filePathLocal.StartsWith("/")) { 
+                                    filePathLocal = filePathLocal.Substring(1);
+                                }
+
                                 Console.WriteLine(filePathLocal);
 
                                 string filePath = Path.Combine(outDir, filePathLocal);
@@ -475,6 +479,10 @@ namespace UnityNSISReader
 
                                 //Console.WriteLine();
 
+                                if (size == 0) {
+                                    File.Create(filePath);
+                                    continue;
+                                }
 
                                 byte[] data = new byte[size];
                                 Array.Copy(sizeData, data, 4);


### PR DESCRIPTION
* Newer versions of Unity's Windows installer have headers that are larger than `1 << 20`, leading to access violations later down the process, since raw pointers are being used.
* Extracting empty files (`size == 0`) lead to exceptions since the `data` array ended up being empty and the copy operation fails.
* Some files in the installer has `/` prefixed to their path, confusing `Path.Combine` and leading to files being extracted into the root of a partition instead of the specified directory.

The fixes are confirmed to work from Unity 2022 to the latest Unity 6 version released in May 4, though I only used it to extract IL2CPP files.